### PR TITLE
feat: direct prod upload support

### DIFF
--- a/k8s-conf-main.yaml
+++ b/k8s-conf-main.yaml
@@ -71,6 +71,9 @@ spec:
         - mountPath: /mnt/gcs
           name: cruc-upload-vol2
           readOnly: true
+        - mountPath: /mnt/gcs-prod
+          name: mf-storage-prod-vol
+          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -89,6 +92,10 @@ spec:
       - name: cruc-upload-vol2
         persistentVolumeClaim:
           claimName: cruc-upload-pvc2
+          readOnly: true
+      - name: mf-storage-prod-vol
+        persistentVolumeClaim:
+          claimName: mf-storage-prod-pvc
           readOnly: true
 ---
 apiVersion: apps/v1
@@ -164,6 +171,9 @@ spec:
         - mountPath: /mnt/gcs
           name: cruc-upload-vol2
           readOnly: true
+        - mountPath: /mnt/gcs-prod
+          name: mf-storage-prod-vol
+          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -182,6 +192,10 @@ spec:
       - name: cruc-upload-vol2
         persistentVolumeClaim:
           claimName: cruc-upload-pvc2
+          readOnly: true
+      - name: mf-storage-prod-vol
+        persistentVolumeClaim:
+          claimName: mf-storage-prod-pvc
           readOnly: true
 ---
 apiVersion: apps/v1
@@ -257,6 +271,9 @@ spec:
         - mountPath: /mnt/gcs
           name: cruc-upload-vol2
           readOnly: true
+        - mountPath: /mnt/gcs-prod
+          name: mf-storage-prod-vol
+          readOnly: true
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
@@ -275,4 +292,8 @@ spec:
       - name: cruc-upload-vol2
         persistentVolumeClaim:
           claimName: cruc-upload-pvc2
+          readOnly: true
+      - name: mf-storage-prod-vol
+        persistentVolumeClaim:
+          claimName: mf-storage-prod-pvc
           readOnly: true

--- a/src/consumer_ingestion_process.py
+++ b/src/consumer_ingestion_process.py
@@ -70,6 +70,8 @@ def callback(ch, method, props, body):
         dataset_to_process = filename
     elif filename.startswith('crucible-uploads'):
         dataset_to_process = filename.replace('crucible-uploads', '/mnt/gcs', 1)
+    elif filename.startswith('mf-storage-prod'):
+        dataset_to_process = filename.replace('mf-storage-prod', '/mnt/gcs/mf-storage-prod', 1)
     else:
         logger.error(f"Unexpected filename format, cannot resolve path: {filename}")
         ch.basic_ack(delivery_tag=method.delivery_tag)

--- a/src/data_ingestion.py
+++ b/src/data_ingestion.py
@@ -1,7 +1,6 @@
 # packages
-import json
 import logging
-from .constants import sql_import_attr
+from .constants import sql_import_attr, sql_export_attr
 from .utils import sanitize_metadata
 
 from .ingestors.scope_foundry_ingestors import ( SimpleTiledImageScopeFoundryH5Ingestor,
@@ -134,10 +133,6 @@ def data_ingestion(dataset_to_process: str,
                    ingestion_class=None):
     
     logger.info("running the data_ingestion function")
-    
-    # set up
-    storage_bucket = 'mf-storage-prod'
-    ingest_json_fname = f"{dsid}_ingest_{timestamp}_{reqid}.json"
 
     ig, ingestion_class = find_supported_ingestor(dataset_to_process, dsid, ingestion_class, ingestor_list)
     if ig is None:
@@ -166,22 +161,13 @@ def data_ingestion(dataset_to_process: str,
         logger.info("no dataset found to update from")
     
     
-    # send to gcs
-    ig.to_google_cloud_storage(storage_bucket,
-                               jsonfile = ingest_json_fname)
-    logger.info(f"Created json file {ingest_json_fname=} and copied to GCS")
-    
-    # only do this if ingestor found: update SQL database
-    with open(ingest_json_fname) as j:
-        D = json.load(j)
+    keywords = ig.keywords
+    ingestion_class = ig.ingestion_class
+    thumbnails = ig.thumbnails
+    md = sanitize_metadata(ig.scientific_metadata)
 
-    keywords = D.pop('keywords') 
-    ingestion_class = D.pop('ingestion_class')
-    thumbnails = D.pop('thumbnails')
-    md = sanitize_metadata(D.pop("scientific_metadata"))
-
-    for remove_field in ['acl', 'ingestion_githash']:
-        _ = D.pop(remove_field)
+    skip_fields = {'keywords', 'ingestion_class', 'thumbnails', 'scientific_metadata', 'acl', 'ingestion_githash'}
+    D = {k: getattr(ig, k) for k in sql_export_attr if k not in skip_fields}
 
     # send the data
     ds = client.datasets.update(ig.unique_id, **D)

--- a/src/ingestors/crucible_ingestor.py
+++ b/src/ingestors/crucible_ingestor.py
@@ -99,7 +99,7 @@ class CrucibleDatasetIngestor(Dataset):
             file_dir = os.path.dirname(self.file_to_upload)
             drive_name = None
 
-            if file_dir.startswith('/mnt/gcs'):
+            if file_dir.startswith('/mnt/gcs/'):
                 crucible_upload_subdir = file_dir.split('/')[4]
                 drive_name = INSTRUMENT_DRIVES.get(crucible_upload_subdir)
             


### PR DESCRIPTION
## Summary
- `data_ingestion.py` — removes GCS file copy and JSON intermediary; reads metadata directly from `ig` attributes
- `consumer_ingestion_process.py` — handles `mf-storage-prod/...` paths via `/mnt/gcs-prod` mount
- `crucible_ingestor.py` — tightened `/mnt/gcs/` path check to avoid index error on `/mnt/gcs-prod` paths
- `k8s-conf-main.yaml` — adds `mf-storage-prod-pvc` mount at `/mnt/gcs-prod` to all main ingestion pods

## Pairs with
crucible-api PR #158 — files now upload directly to `mf-storage-prod`; ingestor reads from there instead of moving files from staging bucket